### PR TITLE
Adds update channel commands and tests

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/redis/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/redis/_params.py
@@ -49,7 +49,7 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
         c.argument('redis_version', help='Redis version. This should be in the form \'major[.minor]\' (only \'major\' is required) or the value \'latest\' which refers to the latest stable Redis version that is available. Supported versions: 4.0, 6.0 (latest). Default value is \'latest\'.')
         c.argument('mi_system_assigned', arg_type=system_identity_type)
         c.argument('mi_user_assigned', arg_type=user_identity_type)
-        c.argument('update_channel',arg_type=get_enum_type(UpdateChannel), help='Specifies the update channel for the monthly Redis updates your Redis Cache will receive. Caches using "Preview" update channel get latest Redis updates at least 4 weeks ahead of "Stable" channel caches. Default value is "Stable".')
+        c.argument('update_channel', arg_type=get_enum_type(UpdateChannel), help='Specifies the update channel for the monthly Redis updates your Redis Cache will receive. Caches using "Preview" update channel get latest Redis updates at least 4 weeks ahead of "Stable" channel caches. Default value is "Stable".')
 
     with self.argument_context('redis firewall-rules list') as c:
         c.argument('cache_name', arg_type=cache_name, id_part=None)

--- a/src/azure-cli/azure/cli/command_modules/redis/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/redis/_params.py
@@ -8,7 +8,7 @@ from knack.arguments import CLIArgumentType
 
 
 def load_arguments(self, _):  # pylint: disable=too-many-statements
-    from azure.mgmt.redis.models import RebootType, RedisKeyType, SkuName, TlsVersion, ReplicationRole
+    from azure.mgmt.redis.models import RebootType, RedisKeyType, SkuName, TlsVersion, ReplicationRole, UpdateChannel
     from azure.cli.command_modules.redis._validators import JsonString, ScheduleEntryList
     from azure.cli.command_modules.redis.custom import allowed_c_family_sizes, allowed_p_family_sizes, allowed_auth_methods
     from azure.cli.core.commands.parameters import get_enum_type, tags_type, zones_type
@@ -49,6 +49,7 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
         c.argument('redis_version', help='Redis version. This should be in the form \'major[.minor]\' (only \'major\' is required) or the value \'latest\' which refers to the latest stable Redis version that is available. Supported versions: 4.0, 6.0 (latest). Default value is \'latest\'.')
         c.argument('mi_system_assigned', arg_type=system_identity_type)
         c.argument('mi_user_assigned', arg_type=user_identity_type)
+        c.argument('update_channel',arg_type=get_enum_type(UpdateChannel), help='Specifies the update channel for the monthly Redis updates your Redis Cache will receive. Caches using "Preview" update channel get latest Redis updates at least 4 weeks ahead of "Stable" channel caches. Default value is "Stable".')
 
     with self.argument_context('redis firewall-rules list') as c:
         c.argument('cache_name', arg_type=cache_name, id_part=None)

--- a/src/azure-cli/azure/cli/command_modules/redis/tests/latest/test_redis_scenario.py
+++ b/src/azure-cli/azure/cli/command_modules/redis/tests/latest/test_redis_scenario.py
@@ -586,7 +586,7 @@ class RedisCacheTests(ScenarioTest):
             time.sleep(5*60)
         self.cmd('az redis update -n {name} -g {rg} --set "RedisVersion=6.0" "UpdateChannel=Preview"')
         if self.is_live:
-            time.sleep(10*60)
+            time.sleep(20*60)
         result = self.cmd('az redis show -n {name} -g {rg}').get_output_in_json()
         assert result['UpdateChannel'] == 'Preview'
         

--- a/src/azure-cli/azure/cli/command_modules/redis/tests/latest/test_redis_scenario.py
+++ b/src/azure-cli/azure/cli/command_modules/redis/tests/latest/test_redis_scenario.py
@@ -570,3 +570,23 @@ class RedisCacheTests(ScenarioTest):
         self.cmd('az redis create -n {name} -g {rg} -l {location} --sku {sku} --vm-size {size}')
         result = self.cmd('az redis flush -g {rg} -n {name} -y').get_output_in_json()
         assert result['status'] == 'Succeeded'
+
+    @ResourceGroupPreparer(name_prefix='cli_test_redis')
+    def test_redis_cache_update_channel(self, resource_group):
+        self.kwargs = {
+            'rg': resource_group,
+            'name': self.create_random_name(prefix=name_prefix, length=24),
+            'location': location,
+            'sku': premium_sku,
+            'size': premium_size
+        }
+
+        self.cmd('az redis create -n {name} -g {rg} -l {location} --sku {sku} --vm-size {size}')
+        if self.is_live:
+            time.sleep(5*60)
+        self.cmd('az redis update -n {name} -g {rg} --set "RedisVersion=6.0" "UpdateChannel=Preview"')
+        if self.is_live:
+            time.sleep(10*60)
+        result = self.cmd('az redis show -n {name} -g {rg}').get_output_in_json()
+        assert result['UpdateChannel'] == 'Preview'
+        

--- a/src/azure-cli/azure/cli/command_modules/redis/tests/latest/test_redis_scenario.py
+++ b/src/azure-cli/azure/cli/command_modules/redis/tests/latest/test_redis_scenario.py
@@ -586,7 +586,7 @@ class RedisCacheTests(ScenarioTest):
             time.sleep(5*60)
         self.cmd('az redis update -n {name} -g {rg} --set "RedisVersion=6.0" "UpdateChannel=Preview"')
         if self.is_live:
-            time.sleep(20*60)
+            time.sleep(5*60)
         result = self.cmd('az redis show -n {name} -g {rg}').get_output_in_json()
         assert result['UpdateChannel'] == 'Preview'
         


### PR DESCRIPTION
**Related command**

az redis update -n {name} -g Test --set "UpdateChannel=Preview"

**Description**

Added new property to update command. Allowing customers to change the update channel for the redis cache.

**Testing Guide**

az redis update -n {name} -g {rg} --set "RedisVersion=6.0" "UpdateChannel=Preview"

**History Notes**

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
